### PR TITLE
[fix] #12 Dependabot PRの依存監査エラーを解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             exit 1
           fi
 
-          if git log --format='%ae%n%ce' | grep -Evq '(@users\.noreply\.github\.com|@github\.com)$'; then
+          if git log "${{ github.event.pull_request.head.sha || github.sha }}" --format='%ae%n%ce' | grep -Evq '(@users\.noreply\.github\.com|@github\.com)$'; then
             echo 'Error: commit email addresses must use a GitHub noreply address.' >&2
             exit 1
           fi

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7,6 +7,8 @@ settings:
 overrides:
   brace-expansion: 5.0.9
   fast-uri: 3.1.5
+  js-yaml@4.3.0: 4.3.1
+  nanoid@3.3.17: 3.3.18
   postcss: 8.5.23
 
 importers:
@@ -1799,8 +1801,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@4.3.0:
-    resolution: {integrity: sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==}
+  js-yaml@4.3.1:
+    resolution: {integrity: sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==}
     hasBin: true
 
   js-yaml@5.2.2:
@@ -2091,8 +2093,8 @@ packages:
   muggle-string@0.4.1:
     resolution: {integrity: sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==}
 
-  nanoid@3.3.17:
-    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
+  nanoid@3.3.18:
+    resolution: {integrity: sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2965,7 +2967,7 @@ snapshots:
     dependencies:
       '@types/hast': 3.0.5
       '@types/mdast': 4.0.4
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       picomatch: 4.0.5
       retext-smartypants: 6.2.0
       shiki: 4.3.1
@@ -3926,7 +3928,7 @@ snapshots:
       github-slugger: 2.0.0
       html-escaper: 3.0.3
       http-cache-semantics: 4.2.0
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       jsonc-parser: 3.3.1
       magic-string: 1.1.0
       magicast: 0.5.3
@@ -4068,7 +4070,7 @@ snapshots:
     dependencies:
       env-paths: 2.2.1
       import-fresh: 3.3.1
-      js-yaml: 4.3.0
+      js-yaml: 4.3.1
       parse-json: 5.2.0
     optionalDependencies:
       typescript: 6.0.3
@@ -4566,7 +4568,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@4.3.0:
+  js-yaml@4.3.1:
     dependencies:
       argparse: 2.0.1
 
@@ -4940,7 +4942,7 @@ snapshots:
 
   muggle-string@0.4.1: {}
 
-  nanoid@3.3.17: {}
+  nanoid@3.3.18: {}
 
   natural-compare@1.4.0: {}
 
@@ -5071,7 +5073,7 @@ snapshots:
 
   postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.17
+      nanoid: 3.3.18
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -5,4 +5,6 @@ allowBuilds:
 overrides:
   brace-expansion: 5.0.9
   fast-uri: 3.1.5
+  js-yaml@4.3.0: 4.3.1
+  nanoid@3.3.17: 3.3.18
   postcss: 8.5.23


### PR DESCRIPTION
## 概要

- 脆弱なjs-yaml@4.3.0だけを4.3.1へ置換
- 脆弱なnanoid@3.3.17だけを3.3.18へ置換
- Dependabot PRに共通する依存監査エラーを解消
- PRでは実際のhead SHAを起点にコミットメールを検査
- GitHub生成の一時マージコミットによる誤検知を解消

## 確認

- pnpm install --frozen-lockfile
- pnpm audit --audit-level moderate
- pnpm check
- PRの実コミット履歴だけをメール検査対象にできること

Closes #12
Closes #16
