### PR TITLE
[fix] #11 GA4のページビュー送信を修正

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -24,8 +24,9 @@ const ogImage = new URL("/images/og.png", Astro.url.origin);
       src="https://www.googletagmanager.com/gtag/js?id=G-V8C2P15644"></script>
     <script is:inline>
       window.dataLayer = window.dataLayer || [];
-      function gtag(...args) {
-        window.dataLayer.push(args);
+      function gtag() {
+        // eslint-disable-next-line prefer-rest-params -- gtag.js requires an Arguments object.
+        window.dataLayer.push(arguments);
       }
       gtag("js", new Date());
 


### PR DESCRIPTION
## 概要

- gtag.js公式形式に合わせてArgumentsオブジェクトをdataLayerへ追加
- GA4へのpage_view送信を復旧

## 確認

- pnpm check
- Playwrightでtid=G-V8C2P15644、en=page_viewを確認

Closes #11