### PR TITLE
[fix] #16 PRのコミットメール検査を修正

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
             exit 1
           fi
 
-          if git log --format='%ae%n%ce' | grep -Evq '(@users\.noreply\.github\.com|@github\.com)$'; then
+          if git log "${{ github.event.pull_request.head.sha || github.sha }}" --format='%ae%n%ce' | grep -Evq '(@users\.noreply\.github\.com|@github\.com)$'; then
             echo 'Error: commit email addresses must use a GitHub noreply address.' >&2
             exit 1
           fi


### PR DESCRIPTION
## 概要

Pull Requestのコミットメール検査からGitHub生成の一時マージコミットを除外し、規約準拠した実コミットが誤検知される問題を修正します。

## 変更内容

- `pull_request` では実際のhead SHAを起点にコミット履歴を検査
- `push` では対象の `github.sha` を起点にコミット履歴を検査
- 既存のメールアドレス規約と全履歴検査は維持

## 確認内容

- `pnpm check`
- PR #13、#14のhead履歴が規約準拠であること
- GitHub生成の一時マージコミットで既存の誤検知を再現できること
- `actionlint` はローカル未導入のため未確認

Closes #16
