### PR TITLE
[fix] #15 canonicalとOGP画像のlocalhostを解消

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,7 @@
 import { defineConfig } from "astro/config";
 
 export default defineConfig({
+  site: "https://endoyuki.jp",
   output: "static",
   trailingSlash: "always",
   build: {


### PR DESCRIPTION
## 概要

Astroの本番サイトURLを設定し、canonicalとOGP画像URLへlocalhostが出力される問題を修正します。

## 変更内容

- `astro.config.mjs` の `site` に `https://endoyuki.jp` を設定
- canonicalとOGP画像URLを本番originから生成

## 確認内容

- `pnpm check`
- 生成HTMLに `localhost` が含まれないこと
- 全ページのcanonicalとOGP画像URLが `https://endoyuki.jp` になること

Closes #15
