### PR TITLE
[fix] #19 Twitter Cardを大きな画像表示に変更

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -51,6 +51,7 @@ const ogImage = new URL("/images/og.png", Astro.url.origin);
     <meta property="og:image:width" content="1200" />
     <meta property="og:image:height" content="630" />
     <meta property="og:image:alt" content="YUKI ENDO / FRONTEND ENGINEER" />
+    <meta name="twitter:card" content="summary_large_image" />
     <link rel="canonical" href={canonical} />
     <link
       rel="icon"


### PR DESCRIPTION
## 概要

Twitter/Xで共有した際のカードを大きな画像形式で表示します。

## 変更内容

- `twitter:card`へ`summary_large_image`を設定
- 既存のOG画像をカード画像として利用

## 確認

- `pnpm check`
- 生成HTML全4ページの`twitter:card`を確認

Closes #19